### PR TITLE
chore: remove Dify branding

### DIFF
--- a/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
@@ -16,10 +16,8 @@ import List from '@/app/components/base/chat/chat-with-history/sidebar/list'
 import MenuDropdown from '@/app/components/share/text-generation/menu-dropdown'
 import Confirm from '@/app/components/base/confirm'
 import RenameModal from '@/app/components/base/chat/chat-with-history/sidebar/rename-modal'
-import DifyLogo from '@/app/components/base/logo/dify-logo'
 import type { ConversationItem } from '@/models/share'
 import cn from '@/utils/classnames'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 
 type Props = {
   isPanel?: boolean
@@ -46,7 +44,6 @@ const Sidebar = ({ isPanel }: Props) => {
     isResponding,
   } = useChatWithHistoryContext()
   const isSidebarCollapsed = sidebarCollapseState
-  const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
   const [showConfirm, setShowConfirm] = useState<ConversationItem | null>(null)
   const [showRename, setShowRename] = useState<ConversationItem | null>(null)
 
@@ -139,23 +136,6 @@ const Sidebar = ({ isPanel }: Props) => {
       </div>
       <div className='flex shrink-0 items-center justify-between p-3'>
         <MenuDropdown hideLogout={isInstalledApp} placement='top-start' data={appData?.site} />
-        {/* powered by */}
-        <div className='shrink-0'>
-          {!appData?.custom_config?.remove_webapp_brand && (
-            <div className={cn(
-              'flex shrink-0 items-center gap-1.5 px-1',
-            )}>
-              <div className='system-2xs-medium-uppercase text-text-tertiary'>{t('share.chat.poweredBy')}</div>
-              {
-                systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-                  ? <img src={systemFeatures.branding.workspace_logo} alt='logo' className='block h-5 w-auto' />
-                  : appData?.custom_config?.replace_webapp_logo
-                    ? <img src={`${appData?.custom_config?.replace_webapp_logo}`} alt='logo' className='block h-5 w-auto' />
-                    : <DifyLogo size='small' />
-              }
-            </div>
-          )}
-        </div>
         {!!showConfirm && (
           <Confirm
             title={t('share.chat.deleteConversation.title')}

--- a/web/app/components/base/chat/embedded-chatbot/header/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/header/index.tsx
@@ -9,11 +9,8 @@ import {
 } from '../context'
 import Tooltip from '@/app/components/base/tooltip'
 import ActionButton from '@/app/components/base/action-button'
-import Divider from '@/app/components/base/divider'
 import ViewFormDropdown from '@/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown'
-import DifyLogo from '@/app/components/base/logo/dify-logo'
 import cn from '@/utils/classnames'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 
 export type IHeaderProps = {
   isMobile?: boolean
@@ -33,7 +30,6 @@ const Header: FC<IHeaderProps> = ({
 }) => {
   const { t } = useTranslation()
   const {
-    appData,
     currentConversationId,
     inputsForms,
   } = useEmbeddedChatbotContext()
@@ -43,7 +39,6 @@ const Header: FC<IHeaderProps> = ({
   const [parentOrigin, setParentOrigin] = useState('')
   const [showToggleExpandButton, setShowToggleExpandButton] = useState(false)
   const [expanded, setExpanded] = useState(false)
-  const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
 
   const handleMessageReceived = useCallback((event: MessageEvent) => {
     let currentParentOrigin = parentOrigin
@@ -80,26 +75,6 @@ const Header: FC<IHeaderProps> = ({
     return (
       <div className='flex h-14 shrink-0 items-center justify-end p-3'>
         <div className='flex items-center gap-1'>
-          {/* powered by */}
-          <div className='shrink-0'>
-            {!appData?.custom_config?.remove_webapp_brand && (
-              <div className={cn(
-                'flex shrink-0 items-center gap-1.5 px-2',
-              )}>
-                <div className='system-2xs-medium-uppercase text-text-tertiary'>{t('share.chat.poweredBy')}</div>
-                {
-                  systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-                    ? <img src={systemFeatures.branding.workspace_logo} alt='logo' className='block h-5 w-auto' />
-                    : appData?.custom_config?.replace_webapp_logo
-                      ? <img src={`${appData?.custom_config?.replace_webapp_logo}`} alt='logo' className='block h-5 w-auto' />
-                      : <DifyLogo size='small' />
-                }
-              </div>
-            )}
-          </div>
-          {currentConversationId && (
-            <Divider type='vertical' className='h-3.5' />
-          )}
           {
             showToggleExpandButton && (
               <Tooltip

--- a/web/app/components/base/chat/embedded-chatbot/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/index.tsx
@@ -2,7 +2,6 @@
 import {
   useEffect,
 } from 'react'
-import { useTranslation } from 'react-i18next'
 import {
   EmbeddedChatbotContext,
   useEmbeddedChatbotContext,
@@ -16,10 +15,8 @@ import Loading from '@/app/components/base/loading'
 import LogoHeader from '@/app/components/base/logo/logo-embedded-chat-header'
 import Header from '@/app/components/base/chat/embedded-chatbot/header'
 import ChatWrapper from '@/app/components/base/chat/embedded-chatbot/chat-wrapper'
-import DifyLogo from '@/app/components/base/logo/dify-logo'
 import cn from '@/utils/classnames'
 import useDocumentTitle from '@/hooks/use-document-title'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 
 const Chatbot = () => {
   const {
@@ -31,8 +28,6 @@ const Chatbot = () => {
     handleNewConversation,
     themeBuilder,
   } = useEmbeddedChatbotContext()
-  const { t } = useTranslation()
-  const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
 
   const customConfig = appData?.custom_config
   const site = appData?.site
@@ -71,25 +66,6 @@ const Chatbot = () => {
           )}
         </div>
       </div>
-      {/* powered by */}
-      {isMobile && (
-        <div className='flex h-[60px] shrink-0 items-center pl-2'>
-          {!appData?.custom_config?.remove_webapp_brand && (
-            <div className={cn(
-              'flex shrink-0 items-center gap-1.5 px-2',
-            )}>
-              <div className='system-2xs-medium-uppercase text-text-tertiary'>{t('share.chat.poweredBy')}</div>
-              {
-                systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-                  ? <img src={systemFeatures.branding.workspace_logo} alt='logo' className='block h-5 w-auto' />
-                  : appData?.custom_config?.replace_webapp_logo
-                    ? <img src={`${appData?.custom_config?.replace_webapp_logo}`} alt='logo' className='block h-5 w-auto' />
-                    : <DifyLogo size='small' />
-              }
-            </div>
-          )}
-        </div>
-      )}
     </div>
   )
 }

--- a/web/app/components/share/text-generation/index.tsx
+++ b/web/app/components/share/text-generation/index.tsx
@@ -35,10 +35,8 @@ import Toast from '@/app/components/base/toast'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { Resolution, TransferMethod } from '@/types/app'
 import { useAppFavicon } from '@/hooks/use-app-favicon'
-import DifyLogo from '@/app/components/base/logo/dify-logo'
 import cn from '@/utils/classnames'
 import { AccessMode } from '@/models/access-control'
-import { useGlobalPublicStore } from '@/context/global-public-context'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { useWebAppStore } from '@/context/web-app-context'
 
@@ -90,7 +88,6 @@ const TextGeneration: FC<IMainProps> = ({
     doSetInputs(newInputs)
     inputsRef.current = newInputs
   }, [])
-  const systemFeatures = useGlobalPublicStore(s => s.systemFeatures)
   const [appId, setAppId] = useState<string>('')
   const [siteInfo, setSiteInfo] = useState<SiteInfo | null>(null)
   const [customConfig, setCustomConfig] = useState<Record<string, any> | null>(null)
@@ -583,23 +580,6 @@ const TextGeneration: FC<IMainProps> = ({
             />
           )}
         </div>
-        {/* powered by */}
-        {!customConfig?.remove_webapp_brand && (
-          <div className={cn(
-            'flex shrink-0 items-center gap-1.5 bg-components-panel-bg py-3',
-            isPC ? 'px-8' : 'px-4',
-            !isPC && resultExisted && 'rounded-b-2xl border-b-[0.5px] border-divider-regular',
-          )}>
-            <div className='system-2xs-medium-uppercase text-text-tertiary'>{t('share.chat.poweredBy')}</div>
-            {
-              systemFeatures.branding.enabled && systemFeatures.branding.workspace_logo
-                ? <img src={systemFeatures.branding.workspace_logo} alt='logo' className='block h-5 w-auto' />
-                : customConfig?.replace_webapp_logo
-                  ? <img src={`${customConfig?.replace_webapp_logo}`} alt='logo' className='block h-5 w-auto' />
-                  : <DifyLogo size='small' />
-            }
-          </div>
-        )}
       </div>
       {/* Result */}
       <div className={cn(

--- a/web/i18n/en-US/custom.ts
+++ b/web/i18n/en-US/custom.ts
@@ -8,8 +8,8 @@ const translation = {
   },
   webapp: {
     title: 'Customize web app brand',
-    removeBrand: 'Remove Powered by Dify',
-    changeLogo: 'Change Powered by Brand Image',
+    removeBrand: 'Remove branding',
+    changeLogo: 'Change brand image',
     changeLogoTip: 'SVG or PNG format with a minimum size of 40x40px',
   },
   app: {


### PR DESCRIPTION
## Summary
- remove "Powered by Dify" sections from embedded chatbot UI
- drop Dify-specific branding strings in English translations

## Testing
- `pnpm lint` *(fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/oxlint: Forbidden)*
- `pnpm eslint app/components/base/chat/embedded-chatbot/index.tsx app/components/base/chat/embedded-chatbot/header/index.tsx app/components/base/chat/chat-with-history/sidebar/index.tsx app/components/share/text-generation/index.tsx i18n/en-US/custom.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a427b94a008332a2b53c9dd2b2caa1